### PR TITLE
Fixed issue in iOS settings where the value was used as the key and the ...

### DIFF
--- a/Acr.XamForms.Mobile.iOS/Settings.cs
+++ b/Acr.XamForms.Mobile.iOS/Settings.cs
@@ -33,7 +33,7 @@ namespace Acr.XamForms.Mobile.iOS {
         protected override void AddOrUpdateNative(IEnumerable<KeyValuePair<string, string>> saves) {
             foreach (var item in saves)
                 if (this.CanTouch(item.Key))
-                    prefs.SetString(item.Key, item.Value);
+                    prefs.SetString(item.Value, item.Key);
 
             prefs.Synchronize();
         }


### PR DESCRIPTION
...key as the value on the Set() call.
