### PR TITLE
added Text property to PromptConfig for initial input, use it in Android...

### DIFF
--- a/Acr.XamForms.UserDialogs.Droid/UserDialogService.cs
+++ b/Acr.XamForms.UserDialogs.Droid/UserDialogService.cs
@@ -104,7 +104,8 @@ namespace Acr.XamForms.UserDialogs.Droid {
         public override void Prompt(PromptConfig config) {
             Utils.RequestMainThread(() => {
                 var txt = new EditText(Utils.GetActivityContext()) {
-                    Hint = config.Placeholder
+                    Hint = config.Placeholder,
+                    Text = config.Text
                 };
                 txt.SetMaxLines(1);
 				if (config.IsSecure) {

--- a/Acr.XamForms.UserDialogs/PromptConfig.cs
+++ b/Acr.XamForms.UserDialogs/PromptConfig.cs
@@ -7,6 +7,7 @@ namespace Acr.XamForms.UserDialogs {
 
         public string Title { get; set; }
         public string Message { get; set; }
+        public string Text { get; set; }
         public Action<PromptResult> OnResult { get; set; }
 
         // TODO: can cancel


### PR DESCRIPTION
... UserDialogService
Could not implement and test on iOS and WindowsPhone.
If you don't pull this, even then it would be useful to implement such feature.