### PR TITLE
Update UserDialogService.cs

### DIFF
--- a/Acr.XamForms.UserDialogs.Droid/UserDialogService.cs
+++ b/Acr.XamForms.UserDialogs.Droid/UserDialogService.cs
@@ -107,6 +107,8 @@ namespace Acr.XamForms.UserDialogs.Droid {
                     Hint = config.Placeholder
                 };
                 txt.SetMaxLines(1);
+                txt.SetSingleLine(true);
+                
 				if (config.IsSecure) {
                     txt.TransformationMethod = PasswordTransformationMethod.Instance;
 					txt.InputType = InputTypes.ClassText | InputTypes.TextVariationPassword;


### PR DESCRIPTION
In my opinion the EditText must not contain more than one line of text. It feels strange to get a new line on hitting enter in a one line input dialog. With this change the EditText doesn't support more than one line.
I'm not sure if this request fits to your idea of dialog's behaviour. I just want to let you know my opinion about it.