### PR TITLE
Fix #120

### DIFF
--- a/Acr.XamForms.SignaturePad.iOS/SignatureServiceView.cs
+++ b/Acr.XamForms.SignaturePad.iOS/SignatureServiceView.cs
@@ -31,7 +31,7 @@ namespace Acr.XamForms.SignaturePad.iOS {
         public override void LayoutSubviews() {
             var frame = (CGRect)this.Frame;
             var sbframe = (CGRect)UIApplication.SharedApplication.StatusBarFrame;
-            var portrait = UIApplication.SharedApplication.StatusBarOrientation.HasFlag(UIDeviceOrientation.Portrait);
+            var portrait = UIApplication.SharedApplication.StatusBarOrientation.HasFlag(UIInterfaceOrientation.Portrait);
 
             var width = portrait
                 ? frame.Size.Width


### PR DESCRIPTION
Fix for iOS SignaturePad component. StatusBarOrientation is an enum of
type UIInterfaceOrientation. It was checking for a flag from
UIDeviceOrientation. This was causing issues on iOS 8.3 in some cases.