### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,37 +1,37 @@
 ACR Xamarin Forms (Any code here is now officially unsupported)
 =================
 
-###User Dialogs
+### User Dialogs
 This library has been replaced by Acr.UserDialogs
 [Nuget](https://www.nuget.org/packages/Acr.UserDialogs/)
 [Github](https://github.com/aritchie/userdialogs)
 
 
-###Settings
+### Settings
 This library has been replaced by Acr.Settings
 [Nuget](https://www.nuget.org/packages/Acr.Settings/)
 [Github](https://github.com/aritchie/settings)
 
 
-###Device Info
+### Device Info
 This library has been replaced by Acr.DeviceInfo
 [Nuget](https://www.nuget.org/packages/Acr.DeviceInfo/)
 [Github](https://github.com/aritchie/deviceinfo)
 
 
-###Signature Pad
+### Signature Pad
 Control provided by [Xamarin Signature Pad](https://github.com/xamarin/SignaturePad).  You can take the code from here or nuget, but it comes with no support
 
 
-##Deprecated Libraries
+## Deprecated Libraries
 
-##Camera & Gallery
+## Camera & Gallery
 This library is now deprecated.  Please use James Montemagno's excellent media plugin 
 [Github](https://github.com/jamesmontemagno/Xamarin.Plugins/tree/master/Media)
 [Nuget](https://www.nuget.org/packages/Xam.Plugin.Media/)
 
 
-##Location Services
+## Location Services
 This library is now deprecated.  Please use James Montemagno's excellent geolocation plugin 
 [Github](https://github.com/jamesmontemagno/Xamarin.Plugins/tree/master/Geolocation)
 [Nuget](https://www.nuget.org/packages/Xam.Plugin.Geolocation/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
